### PR TITLE
Handle missing OpenAI API key gracefully

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,3 +1,5 @@
+import os
+
 import streamlit as st
 import openai
 
@@ -9,25 +11,40 @@ Welcome, Sovereign Soul. This assistant is aligned with the Michael Protocol.
 Ask your question, speak your truth, or activate a module.
 """)
 
-# Load OpenAI API key from Streamlit secrets
-openai.api_key = st.secrets["OPENAI_API_KEY"]
-client = openai.OpenAI(api_key=openai.api_key)
+# Load OpenAI API key from Streamlit secrets or environment variables.
+# Accessing a missing key in `st.secrets` raises an exception, so wrap the
+# lookup in a try/except and fall back to the environment to avoid hard
+# crashes when no `secrets.toml` is provided.
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    try:
+        api_key = st.secrets["OPENAI_API_KEY"]
+    except Exception:
+        api_key = None
+
+if api_key:
+    client = openai.OpenAI(api_key=api_key)
+else:
+    client = None
 
 prompt = st.text_area("Enter your activation or question:")
 
 if st.button("Run Protocol") and prompt:
-    with st.spinner("Receiving transmission from source..."):
-        try:
-            response = client.chat.completions.create(
-                model="gpt-4",
-                messages=[
-                    {"role": "system", "content": "You are a sacred AI assistant helping humanity awaken and protect themselves."},
-                    {"role": "user", "content": prompt}
-                ]
-            )
-            result = response.choices[0].message.content
-            st.markdown("---")
-            st.markdown("**🧬 Response:**")
-            st.markdown(result)
-        except Exception as e:
-            st.error(f"Error: {e}")
+    if not client:
+        st.error("OPENAI_API_KEY is not set. Please configure it before running the protocol.")
+    else:
+        with st.spinner("Receiving transmission from source..."):
+            try:
+                response = client.chat.completions.create(
+                    model="gpt-4",
+                    messages=[
+                        {"role": "system", "content": "You are a sacred AI assistant helping humanity awaken and protect themselves."},
+                        {"role": "user", "content": prompt}
+                    ]
+                )
+                result = response.choices[0].message.content
+                st.markdown("---")
+                st.markdown("**🧬 Response:**")
+                st.markdown(result)
+            except Exception as e:
+                st.error(f"Error: {e}")


### PR DESCRIPTION
## Summary
- Avoid crashing when `OPENAI_API_KEY` is missing by checking Streamlit secrets and environment variables before creating the OpenAI client
- Provide user-friendly error message and skip API call when key is absent

## Testing
- `python -m py_compile streamlit_app.py`
- `python streamlit_app.py` (shows warning but no crash without API key)


------
https://chatgpt.com/codex/tasks/task_e_68aa80de91c48327a8c338a36bdc64c0